### PR TITLE
Dockerfile build improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,25 @@ FROM base AS builder
 
 WORKDIR /app
 
-COPY . .
+# Copy dependency files first for better caching
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY patches ./patches
+
+# Copy package.json files from all workspaces
+COPY apps/server/package.json ./apps/server/package.json
+COPY apps/client/package.json ./apps/client/package.json
+COPY packages/editor-ext/package.json ./packages/editor-ext/package.json
 
 ENV NX_SOCKET_DIR=/tmp/nx-tmp
 
+# Install dependencies (this layer will be cached unless dependencies change)
 RUN npm install -g pnpm@10.4.0
 RUN pnpm install --frozen-lockfile
+
+# Copy source code after dependencies are installed
+COPY . .
+
+# Build the project
 RUN pnpm build
 
 FROM base AS installer

--- a/packages/editor-ext/project.json
+++ b/packages/editor-ext/project.json
@@ -1,0 +1,4 @@
+{
+  "name": "@docmost/editor-ext",
+  "root": "packages/editor-ext"
+}


### PR DESCRIPTION
Splits install and build stages to get more out of caching.

`packages/editor-ext/project.json` seems to help with build errors, although I can't quite remember why. I was having issues with a package being loaded twice.