### PR TITLE
fix: comment duplication on create and API key custom date picker

### DIFF
--- a/apps/client/src/features/api-key/components/create-api-key-modal.tsx
+++ b/apps/client/src/features/api-key/components/create-api-key-modal.tsx
@@ -57,7 +57,7 @@ export default function CreateApiKeyModal() {
     let expiresAt: string | undefined;
 
     if (values.expiration === "custom" && values.customDate) {
-      expiresAt = values.customDate.toISOString();
+      expiresAt = new Date(values.customDate).toISOString();
     } else if (values.expiration !== "never") {
       const days = parseInt(values.expiration, 10);
       expiresAt = new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
@@ -106,7 +106,7 @@ export default function CreateApiKeyModal() {
                 <DateInput
                   label={t("Custom expiration date")}
                   placeholder={t("Select expiration date")}
-                  minDate={new Date()}
+                  minDate={new Date(Date.now() + 24 * 60 * 60 * 1000)}
                   required
                   {...form.getInputProps("customDate")}
                 />

--- a/apps/client/src/features/comment/queries/comment-query.ts
+++ b/apps/client/src/features/comment/queries/comment-query.ts
@@ -67,15 +67,20 @@ export function useCreateCommentMutation() {
       ) as InfiniteData<IPagination<IComment>> | undefined;
 
       if (cache && cache.pages.length > 0) {
-        const lastIdx = cache.pages.length - 1;
-        queryClient.setQueryData(RQ_KEY(newComment.pageId), {
-          ...cache,
-          pages: cache.pages.map((page, i) =>
-            i === lastIdx
-              ? { ...page, items: [...page.items, newComment] }
-              : page,
-          ),
-        });
+        const alreadyExists = cache.pages.some((page) =>
+          page.items.some((c) => c.id === newComment.id),
+        );
+        if (!alreadyExists) {
+          const lastIdx = cache.pages.length - 1;
+          queryClient.setQueryData(RQ_KEY(newComment.pageId), {
+            ...cache,
+            pages: cache.pages.map((page, i) =>
+              i === lastIdx
+                ? { ...page, items: [...page.items, newComment] }
+                : page,
+            ),
+          });
+        }
       }
 
       notifications.show({ message: t("Comment created successfully") });


### PR DESCRIPTION
# Summary

Made a few bug fixes.

## Comment "false-positive" duplication

- In some cases (wasn't happening in my dev env but sometimes in my prod), there can be a race condition on the way comments are displayed after addition. It can cause an issue where new comments shows two times (duplicated) although it's just a frontend issue and is fixed on hard reload. I added some guardrails to avoid it.

## Error when using custom expiration date for API keys

- Fixes a parsing issue.
- Makes the date picker starts tomorrow instead of today (doesn't make sense for a new API key to expire today).