### PR TITLE
Custom branding - Add primary color and app name customization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # your domain, e.g https://example.com
 APP_URL=http://localhost:3000
 PORT=3000
+# Customize the name displayed in the header and in the tab. Empty fallback to Forkmost
+APP_NAME=
 
 # can be useful for debugging
 VITE_HOST=

--- a/apps/client/src/App.tsx
+++ b/apps/client/src/App.tsx
@@ -44,11 +44,11 @@ export default function App() {
         <Route path={"/forgot-password"} element={<ForgotPassword />} />
         <Route path={"/password-reset"} element={<PasswordReset />} />
         <Route path={"/auth/oidc/callback"} element={<OidcCallbackPage />} />
-        { /* <Route path={"/login/mfa"} element={<MfaChallengePage />} />
+        {/* <Route path={"/login/mfa"} element={<MfaChallengePage />} />
         <Route
           path={"/login/mfa/setup"}
           element={<MfaSetupRequiredPage />}
-        /> */ }
+        /> */}
 
         {!isCloud() && (
           <Route path={"/setup/register"} element={<SetupWorkspace />} />
@@ -71,10 +71,7 @@ export default function App() {
           <Route path={"/s/:spaceSlug"} element={<SpaceHome />} />
           <Route path={"/s/:spaceSlug/graph"} element={<SpaceGraph />} />
           <Route path={"/s/:spaceSlug/trash"} element={<SpaceTrash />} />
-          <Route
-            path={"/s/:spaceSlug/p/:pageSlug"}
-            element={<Page />}
-          />
+          <Route path={"/s/:spaceSlug/p/:pageSlug"} element={<Page />} />
 
           <Route path={"/settings"}>
             <Route path={"account/profile"} element={<AccountSettings />} />

--- a/apps/client/src/components/layouts/global/app-header.tsx
+++ b/apps/client/src/components/layouts/global/app-header.tsx
@@ -12,7 +12,7 @@ import {
 import { useToggleSidebar } from "@/components/layouts/global/hooks/hooks/use-toggle-sidebar.ts";
 import SidebarToggle from "@/components/ui/sidebar-toggle-button.tsx";
 import { useTranslation } from "react-i18next";
-import { isCloud } from "@/lib/config.ts";
+import { isCloud, getAppName } from "@/lib/config.ts";
 import {
   SearchControl,
   SearchMobileControl,
@@ -78,7 +78,7 @@ export function AppHeader() {
             component={Link}
             to="/home"
           >
-            {import.meta.env.VITE_APP_NAME || "Forkmost"}
+            {getAppName()}
           </Text>
 
           <Group ml={50} gap={5} className={classes.links} visibleFrom="sm">

--- a/apps/client/src/components/ui/error-404.tsx
+++ b/apps/client/src/components/ui/error-404.tsx
@@ -3,6 +3,7 @@ import classes from "./error-404.module.css";
 import { Link } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
 import { useTranslation } from "react-i18next";
+import { getAppName } from "@/lib/config";
 
 export function Error404() {
   const { t } = useTranslation();
@@ -10,7 +11,9 @@ export function Error404() {
   return (
     <>
       <Helmet>
-        <title>{t("404 page not found")} - Forkmost</title>
+        <title>
+          {t("404 page not found")} - {getAppName()}
+        </title>
       </Helmet>
       <Container className={classes.root}>
         <Title className={classes.title}>{t("404 page not found")}</Title>

--- a/apps/client/src/features/attachments/services/attachment-service.ts
+++ b/apps/client/src/features/attachments/services/attachment-service.ts
@@ -80,6 +80,22 @@ export async function uploadWorkspaceIcon(file: File): Promise<IAttachment> {
   return uploadIcon(file, AvatarIconType.WORKSPACE_ICON);
 }
 
+export async function uploadWorkspaceFavicon(file: File): Promise<string> {
+  const formData = new FormData();
+  formData.append("image", file);
+
+  const response = await api.post<{ faviconUrl: string }>(
+    "/attachments/upload-favicon",
+    formData,
+    {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    },
+  );
+  return response.faviconUrl;
+}
+
 async function removeIcon(
   type: AvatarIconType,
   spaceId?: string,
@@ -103,4 +119,8 @@ export async function removeSpaceIcon(spaceId: string): Promise<void> {
 
 export async function removeWorkspaceIcon(): Promise<void> {
   await removeIcon(AvatarIconType.WORKSPACE_ICON);
+}
+
+export async function removeWorkspaceFavicon(): Promise<void> {
+  await removeIcon(AvatarIconType.WORKSPACE_FAVICON);
 }

--- a/apps/client/src/features/attachments/types/attachment.types.ts
+++ b/apps/client/src/features/attachments/types/attachment.types.ts
@@ -19,6 +19,7 @@ export enum AvatarIconType {
   AVATAR = "avatar",
   SPACE_ICON = "space-icon",
   WORKSPACE_ICON = "workspace-icon",
+  WORKSPACE_FAVICON = "workspace-favicon",
 }
 
 export enum AttachmentType {

--- a/apps/client/src/features/auth/components/auth-layout.tsx
+++ b/apps/client/src/features/auth/components/auth-layout.tsx
@@ -1,12 +1,20 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Group, Text } from "@mantine/core";
 import classes from "./auth.module.css";
+import { useWorkspacePublicDataQuery } from "@/features/workspace/queries/workspace-query.ts";
+import { applyWorkspaceBranding } from "@/lib/branding.ts";
 
 type AuthLayoutProps = {
   children: React.ReactNode;
 };
 
 export function AuthLayout({ children }: AuthLayoutProps) {
+  const { data: workspace } = useWorkspacePublicDataQuery();
+
+  useEffect(() => {
+    applyWorkspaceBranding(workspace?.settings);
+  }, [workspace?.settings]);
+
   return (
     <>
       <Group justify="center" gap={8} className={classes.logo}>

--- a/apps/client/src/features/share/components/share-shell.tsx
+++ b/apps/client/src/features/share/components/share-shell.tsx
@@ -5,7 +5,7 @@ import {
   Group,
   ScrollArea,
   Text,
-  Tooltip
+  Tooltip,
 } from "@mantine/core";
 import { useGetSharedPageTreeQuery } from "@/features/share/queries/share-query.ts";
 import { Link, useParams } from "react-router-dom";
@@ -15,7 +15,10 @@ import { readOnlyEditorAtom } from "@/features/editor/atoms/editor-atoms.ts";
 import { ThemeToggle } from "@/components/ui/theme-toggle.tsx";
 import { useAtomValue, useSetAtom } from "jotai";
 import { useAtom } from "jotai";
-import { sharedPageTreeAtom, sharedTreeDataAtom } from "@/features/share/atoms/shared-page-atom";
+import {
+  sharedPageTreeAtom,
+  sharedTreeDataAtom,
+} from "@/features/share/atoms/shared-page-atom";
 import { buildSharedPageTree } from "@/features/share/utils";
 import {
   desktopSidebarAtom,
@@ -38,6 +41,7 @@ import {
 import { ShareSearchSpotlight } from "@/features/search/components/share-search-spotlight.tsx";
 import { shareSearchSpotlight } from "@/features/search/constants";
 import { FullWidthToggle } from "@/components/ui/full-width-toggle";
+import { getAppName } from "@/lib/config.ts";
 
 const MemoizedSharedTree = React.memo(SharedTree);
 
@@ -58,8 +62,13 @@ export default function ShareShell({
   const toggleToc = useToggleToc(tableOfContentAsideAtom);
 
   const { shareId } = useParams();
-  const sessionPassword = shareId ? sessionStorage.getItem(`share-password-${shareId}`) : null;
-  const { data } = useGetSharedPageTreeQuery(shareId, sessionPassword || undefined);
+  const sessionPassword = shareId
+    ? sessionStorage.getItem(`share-password-${shareId}`)
+    : null;
+  const { data } = useGetSharedPageTreeQuery(
+    shareId,
+    sessionPassword || undefined,
+  );
   const readOnlyEditor = useAtomValue(readOnlyEditorAtom);
 
   // @ts-ignore
@@ -127,11 +136,8 @@ export default function ShareShell({
                 </Tooltip>
               </>
             )}
-            <Text
-              size="lg"
-              fw={600}
-            >
-              {import.meta.env.VITE_APP_NAME || "Forkmost"}
+            <Text size="lg" fw={600}>
+              {getAppName()}
             </Text>
           </Group>
 
@@ -186,9 +192,7 @@ export default function ShareShell({
         </AppShell.Navbar>
       )}
 
-      <AppShell.Main>
-        {children}
-      </AppShell.Main>
+      <AppShell.Main>{children}</AppShell.Main>
 
       <AppShell.Aside
         p="md"

--- a/apps/client/src/features/user/user-provider.tsx
+++ b/apps/client/src/features/user/user-provider.tsx
@@ -11,6 +11,7 @@ import { useTreeSocket } from "@/features/websocket/use-tree-socket.ts";
 import { useNotificationSocket } from "@/features/notification/hooks/use-notification-socket.ts";
 import { useCollabToken } from "@/features/auth/queries/auth-query.tsx";
 import { Error404 } from "@/components/ui/error-404.tsx";
+import { applyWorkspaceBranding } from "@/lib/branding.ts";
 
 export function UserProvider({ children }: React.PropsWithChildren) {
   const [, setCurrentUser] = useAtom(currentUserAtom);
@@ -50,6 +51,7 @@ export function UserProvider({ children }: React.PropsWithChildren) {
   useEffect(() => {
     if (data && data.user && data.workspace) {
       setCurrentUser(data);
+      applyWorkspaceBranding(data.workspace.settings);
       i18n.changeLanguage(
         data.user.locale === "en" ? "en-US" : data.user.locale,
       );

--- a/apps/client/src/features/workspace/components/settings/components/workspace-branding-form.tsx
+++ b/apps/client/src/features/workspace/components/settings/components/workspace-branding-form.tsx
@@ -1,35 +1,57 @@
 import { workspaceAtom } from "@/features/user/atoms/current-user-atom.ts";
 import { useAtom } from "jotai";
 import { z } from "zod/v4";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { updateWorkspace } from "@/features/workspace/services/workspace-service.ts";
 import { IWorkspace } from "@/features/workspace/types/workspace.types.ts";
-import { Button, ColorInput, Stack, TextInput } from "@mantine/core";
+import {
+  Button,
+  ColorInput,
+  Stack,
+  Text,
+  Image,
+  ActionIcon,
+  Group,
+  Box,
+} from "@mantine/core";
 import { useForm } from "@mantine/form";
 import { zod4Resolver } from "mantine-form-zod-resolver";
 import { notifications } from "@mantine/notifications";
 import useUserRole from "@/hooks/use-user-role.tsx";
 import { useTranslation } from "react-i18next";
 import { applyWorkspaceBranding } from "@/lib/branding.ts";
+import {
+  uploadWorkspaceFavicon,
+  removeWorkspaceFavicon,
+} from "@/features/attachments/services/attachment-service.ts";
+import { IconTrash } from "@tabler/icons-react";
 
 const formSchema = z.object({
   primaryColor: z.string().regex(/^#[0-9A-Fa-f]{6}$/),
-  faviconUrl: z.string().url().or(z.literal("")),
 });
 
 type FormValues = z.infer<typeof formSchema>;
 
+const FAVICON_MAX_SIZE = 100 * 1024; // 100KB
+const FAVICON_ACCEPTED_TYPES = [
+  "image/png",
+  "image/x-icon",
+  "image/svg+xml",
+  "image/webp",
+];
+
 export default function WorkspaceBrandingForm() {
   const { t } = useTranslation();
   const [isLoading, setIsLoading] = useState(false);
+  const [faviconLoading, setFaviconLoading] = useState(false);
   const [workspace, setWorkspace] = useAtom(workspaceAtom);
   const { isOwner } = useUserRole();
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const form = useForm<FormValues>({
     validate: zod4Resolver(formSchema),
     initialValues: {
       primaryColor: workspace?.settings?.appearance?.primaryColor ?? "#1f1f1f",
-      faviconUrl: workspace?.settings?.appearance?.faviconUrl ?? "",
     },
   });
 
@@ -41,7 +63,6 @@ export default function WorkspaceBrandingForm() {
     try {
       const updatedWorkspace = await updateWorkspace({
         primaryColor: data.primaryColor,
-        faviconUrl: data.faviconUrl || undefined,
       });
       setWorkspace(updatedWorkspace);
       applyWorkspaceBranding(updatedWorkspace.settings);
@@ -57,6 +78,93 @@ export default function WorkspaceBrandingForm() {
     form.resetDirty();
   }
 
+  async function handleFaviconUpload(
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    if (
+      !FAVICON_ACCEPTED_TYPES.includes(file.type) &&
+      !file.name.endsWith(".ico")
+    ) {
+      notifications.show({
+        message: t("Invalid file type. Accepted types: PNG, ICO, SVG, WebP"),
+        color: "red",
+      });
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      return;
+    }
+
+    if (file.size > FAVICON_MAX_SIZE) {
+      notifications.show({
+        message: t("File size exceeds 100KB limit"),
+        color: "red",
+      });
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      return;
+    }
+
+    setFaviconLoading(true);
+    try {
+      const faviconUrl = await uploadWorkspaceFavicon(file);
+      const updatedSettings = {
+        ...workspace?.settings,
+        appearance: {
+          ...workspace?.settings?.appearance,
+          faviconUrl,
+        },
+      };
+      const updatedWorkspace = {
+        ...workspace,
+        settings: updatedSettings,
+      } as IWorkspace;
+      setWorkspace(updatedWorkspace);
+      applyWorkspaceBranding(updatedSettings);
+      notifications.show({ message: t("Favicon updated successfully") });
+    } catch (error) {
+      console.error(error);
+      notifications.show({
+        message: t("Failed to upload favicon"),
+        color: "red",
+      });
+    } finally {
+      setFaviconLoading(false);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
+  }
+
+  async function handleDeleteFavicon() {
+    setFaviconLoading(true);
+    try {
+      await removeWorkspaceFavicon();
+      const updatedSettings = {
+        ...workspace?.settings,
+        appearance: {
+          ...workspace?.settings?.appearance,
+          faviconUrl: undefined,
+        },
+      };
+      const updatedWorkspace = {
+        ...workspace,
+        settings: updatedSettings,
+      } as IWorkspace;
+      setWorkspace(updatedWorkspace);
+      applyWorkspaceBranding(updatedSettings);
+      notifications.show({ message: t("Favicon removed successfully") });
+    } catch (error) {
+      console.error(error);
+      notifications.show({
+        message: t("Failed to remove favicon"),
+        color: "red",
+      });
+    } finally {
+      setFaviconLoading(false);
+    }
+  }
+
+  const faviconUrl = workspace?.settings?.appearance?.faviconUrl;
+
   return (
     <form onSubmit={form.onSubmit(handleSubmit)}>
       <Stack mt="md">
@@ -65,11 +173,55 @@ export default function WorkspaceBrandingForm() {
           format="hex"
           {...form.getInputProps("primaryColor")}
         />
-        <TextInput
-          label={t("Favicon URL")}
-          placeholder="https://example.com/favicon.png"
-          {...form.getInputProps("faviconUrl")}
-        />
+
+        <Box>
+          <Text size="sm" fw={500} mb="xs">
+            {t("Favicon")}
+          </Text>
+          <Group gap="sm" align="center">
+            {faviconUrl && (
+              <Image
+                src={faviconUrl}
+                w={32}
+                h={32}
+                fit="contain"
+                alt="Favicon preview"
+              />
+            )}
+            <input
+              type="file"
+              ref={fileInputRef}
+              onChange={handleFaviconUpload}
+              accept="image/png,image/x-icon,image/svg+xml,image/webp,.ico"
+              style={{ display: "none" }}
+            />
+            <Button
+              variant="default"
+              size="xs"
+              onClick={() => fileInputRef.current?.click()}
+              loading={faviconLoading}
+              disabled={faviconLoading}
+            >
+              {faviconUrl ? t("Change") : t("Upload")}
+            </Button>
+            {faviconUrl && (
+              <ActionIcon
+                variant="subtle"
+                color="red"
+                size="sm"
+                onClick={handleDeleteFavicon}
+                disabled={faviconLoading}
+                title={t("Remove favicon")}
+              >
+                <IconTrash size={16} />
+              </ActionIcon>
+            )}
+          </Group>
+          <Text size="xs" c="dimmed" mt={4}>
+            {t("PNG, ICO, SVG, or WebP. Max 100KB.")}
+          </Text>
+        </Box>
+
         <Button
           mt="sm"
           type="submit"

--- a/apps/client/src/features/workspace/components/settings/components/workspace-branding-form.tsx
+++ b/apps/client/src/features/workspace/components/settings/components/workspace-branding-form.tsx
@@ -32,7 +32,7 @@ const formSchema = z.object({
 
 type FormValues = z.infer<typeof formSchema>;
 
-const FAVICON_MAX_SIZE = 100 * 1024; // 100KB
+const FAVICON_MAX_SIZE = 10 * 1024; // 10KB - Need to be changed in the backend too (server/core/attachment/attachment.constants.ts)
 const FAVICON_ACCEPTED_TYPES = [
   "image/png",
   "image/x-icon",
@@ -98,7 +98,7 @@ export default function WorkspaceBrandingForm() {
 
     if (file.size > FAVICON_MAX_SIZE) {
       notifications.show({
-        message: t("File size exceeds 100KB limit"),
+        message: t(`File size exceeds ${FAVICON_MAX_SIZE / 1024}KB limit`),
         color: "red",
       });
       if (fileInputRef.current) fileInputRef.current.value = "";

--- a/apps/client/src/features/workspace/components/settings/components/workspace-branding-form.tsx
+++ b/apps/client/src/features/workspace/components/settings/components/workspace-branding-form.tsx
@@ -1,0 +1,93 @@
+import { workspaceAtom } from "@/features/user/atoms/current-user-atom.ts";
+import { useAtom } from "jotai";
+import { z } from "zod/v4";
+import { useState } from "react";
+import { updateWorkspace } from "@/features/workspace/services/workspace-service.ts";
+import { IWorkspace } from "@/features/workspace/types/workspace.types.ts";
+import { Button, ColorInput, Stack, TextInput } from "@mantine/core";
+import { useForm } from "@mantine/form";
+import { zod4Resolver } from "mantine-form-zod-resolver";
+import { notifications } from "@mantine/notifications";
+import useUserRole from "@/hooks/use-user-role.tsx";
+import { useTranslation } from "react-i18next";
+import { applyWorkspaceBranding } from "@/lib/branding.ts";
+
+const formSchema = z.object({
+  primaryColor: z.string().regex(/^#[0-9A-Fa-f]{6}$/),
+  secondaryColor: z.string().regex(/^#[0-9A-Fa-f]{6}$/),
+  faviconUrl: z.string().url().or(z.literal("")),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+export default function WorkspaceBrandingForm() {
+  const { t } = useTranslation();
+  const [isLoading, setIsLoading] = useState(false);
+  const [workspace, setWorkspace] = useAtom(workspaceAtom);
+  const { isOwner } = useUserRole();
+
+  const form = useForm<FormValues>({
+    validate: zod4Resolver(formSchema),
+    initialValues: {
+      primaryColor: workspace?.settings?.appearance?.primaryColor ?? "#1f1f1f",
+      secondaryColor:
+        workspace?.settings?.appearance?.secondaryColor ?? "#f6f7f9",
+      faviconUrl: workspace?.settings?.appearance?.faviconUrl ?? "",
+    },
+  });
+
+  if (!isOwner) return null;
+
+  async function handleSubmit(data: Partial<IWorkspace>) {
+    setIsLoading(true);
+
+    try {
+      const updatedWorkspace = await updateWorkspace({
+        primaryColor: data.primaryColor,
+        secondaryColor: data.secondaryColor,
+        faviconUrl: data.faviconUrl || undefined,
+      });
+      setWorkspace(updatedWorkspace);
+      applyWorkspaceBranding(updatedWorkspace.settings);
+      notifications.show({ message: t("Updated successfully") });
+    } catch (err) {
+      console.log(err);
+      notifications.show({
+        message: t("Failed to update data"),
+        color: "red",
+      });
+    }
+    setIsLoading(false);
+    form.resetDirty();
+  }
+
+  return (
+    <form onSubmit={form.onSubmit(handleSubmit)}>
+      <Stack mt="md">
+        <ColorInput
+          label={t("Primary theme color")}
+          format="hex"
+          {...form.getInputProps("primaryColor")}
+        />
+        <ColorInput
+          label={t("Secondary theme color")}
+          format="hex"
+          {...form.getInputProps("secondaryColor")}
+        />
+        <TextInput
+          label={t("Favicon URL")}
+          placeholder="https://example.com/favicon.png"
+          {...form.getInputProps("faviconUrl")}
+        />
+        <Button
+          mt="sm"
+          type="submit"
+          disabled={isLoading || !form.isDirty()}
+          loading={isLoading}
+        >
+          {t("Save")}
+        </Button>
+      </Stack>
+    </form>
+  );
+}

--- a/apps/client/src/features/workspace/components/settings/components/workspace-branding-form.tsx
+++ b/apps/client/src/features/workspace/components/settings/components/workspace-branding-form.tsx
@@ -14,7 +14,6 @@ import { applyWorkspaceBranding } from "@/lib/branding.ts";
 
 const formSchema = z.object({
   primaryColor: z.string().regex(/^#[0-9A-Fa-f]{6}$/),
-  secondaryColor: z.string().regex(/^#[0-9A-Fa-f]{6}$/),
   faviconUrl: z.string().url().or(z.literal("")),
 });
 
@@ -30,8 +29,6 @@ export default function WorkspaceBrandingForm() {
     validate: zod4Resolver(formSchema),
     initialValues: {
       primaryColor: workspace?.settings?.appearance?.primaryColor ?? "#1f1f1f",
-      secondaryColor:
-        workspace?.settings?.appearance?.secondaryColor ?? "#f6f7f9",
       faviconUrl: workspace?.settings?.appearance?.faviconUrl ?? "",
     },
   });
@@ -44,7 +41,6 @@ export default function WorkspaceBrandingForm() {
     try {
       const updatedWorkspace = await updateWorkspace({
         primaryColor: data.primaryColor,
-        secondaryColor: data.secondaryColor,
         faviconUrl: data.faviconUrl || undefined,
       });
       setWorkspace(updatedWorkspace);
@@ -68,11 +64,6 @@ export default function WorkspaceBrandingForm() {
           label={t("Primary theme color")}
           format="hex"
           {...form.getInputProps("primaryColor")}
-        />
-        <ColorInput
-          label={t("Secondary theme color")}
-          format="hex"
-          {...form.getInputProps("secondaryColor")}
         />
         <TextInput
           label={t("Favicon URL")}

--- a/apps/client/src/features/workspace/types/workspace.types.ts
+++ b/apps/client/src/features/workspace/types/workspace.types.ts
@@ -27,12 +27,16 @@ export interface IWorkspace {
   mcpEnabled?: boolean;
   trashRetentionDays?: number;
   restrictApiToAdmins?: boolean;
+  primaryColor?: string;
+  secondaryColor?: string;
+  faviconUrl?: string;
 }
 
 export interface IWorkspaceSettings {
   ai?: IWorkspaceAiSettings;
   sharing?: IWorkspaceSharingSettings;
   api?: IWorkspaceApiSettings;
+  appearance?: IWorkspaceAppearanceSettings;
 }
 
 export interface IWorkspaceApiSettings {
@@ -47,6 +51,12 @@ export interface IWorkspaceAiSettings {
 
 export interface IWorkspaceSharingSettings {
   disabled?: boolean;
+}
+
+export interface IWorkspaceAppearanceSettings {
+  primaryColor?: string;
+  secondaryColor?: string;
+  faviconUrl?: string;
 }
 
 export interface ICreateInvite {
@@ -82,6 +92,7 @@ export interface IPublicWorkspace {
   logo: string;
   hostname: string;
   enforceSso: boolean;
+  settings?: IWorkspaceSettings;
   authProviders: IAuthProvider[];
 }
 

--- a/apps/client/src/features/workspace/types/workspace.types.ts
+++ b/apps/client/src/features/workspace/types/workspace.types.ts
@@ -28,7 +28,6 @@ export interface IWorkspace {
   trashRetentionDays?: number;
   restrictApiToAdmins?: boolean;
   primaryColor?: string;
-  secondaryColor?: string;
   faviconUrl?: string;
 }
 
@@ -55,7 +54,6 @@ export interface IWorkspaceSharingSettings {
 
 export interface IWorkspaceAppearanceSettings {
   primaryColor?: string;
-  secondaryColor?: string;
   faviconUrl?: string;
 }
 

--- a/apps/client/src/lib/branding.ts
+++ b/apps/client/src/lib/branding.ts
@@ -1,7 +1,7 @@
 import { IWorkspaceSettings } from "@/features/workspace/types/workspace.types.ts";
 
 const DEFAULT_PRIMARY = "#1f1f1f";
-const DEFAULT_SECONDARY = "#f6f7f9";
+
 const DEFAULT_FAVICON_32 = "/favicon-32x32.png";
 const DEFAULT_FAVICON_16 = "/favicon-16x16.png";
 
@@ -9,7 +9,7 @@ export function applyWorkspaceBranding(settings?: IWorkspaceSettings) {
   const root = document.documentElement;
   const appearance = settings?.appearance;
   const primaryColor = appearance?.primaryColor || DEFAULT_PRIMARY;
-  const secondaryColor = appearance?.secondaryColor || DEFAULT_SECONDARY;
+
   const favicon = appearance?.faviconUrl;
 
   // Mantine runtime variables (applies to buttons, badges, focus rings, etc.)
@@ -31,7 +31,10 @@ export function applyWorkspaceBranding(settings?: IWorkspaceSettings) {
     "--mantine-primary-color-outline",
     `color-mix(in srgb, ${primaryColor} 92%, white)`,
   );
-  root.style.setProperty("--mantine-primary-color-outline-hover", secondaryColor);
+  root.style.setProperty(
+    "--mantine-primary-color-outline-hover",
+    `color-mix(in srgb, ${primaryColor} 70%, white)`,
+  );
 
   // Keep blue palette aligned with selected primary color for components explicitly using `color="blue"`.
   root.style.setProperty("--mantine-color-blue-filled", primaryColor);
@@ -49,7 +52,7 @@ export function applyWorkspaceBranding(settings?: IWorkspaceSettings) {
   const lightThemeMeta = document.querySelector(
     'meta[name="theme-color"][media="(prefers-color-scheme: light)"]',
   );
-  lightThemeMeta?.setAttribute("content", secondaryColor);
+  lightThemeMeta?.setAttribute("content", "#ffffff");
 
   const icon32 = document.querySelector(
     'link[rel="icon"][sizes="32x32"]',

--- a/apps/client/src/lib/branding.ts
+++ b/apps/client/src/lib/branding.ts
@@ -1,0 +1,39 @@
+import { IWorkspaceSettings } from "@/features/workspace/types/workspace.types.ts";
+
+const DEFAULT_PRIMARY = "#1f1f1f";
+const DEFAULT_SECONDARY = "#f6f7f9";
+const DEFAULT_FAVICON_32 = "/favicon-32x32.png";
+const DEFAULT_FAVICON_16 = "/favicon-16x16.png";
+
+export function applyWorkspaceBranding(settings?: IWorkspaceSettings) {
+  const appearance = settings?.appearance;
+  const primaryColor = appearance?.primaryColor || DEFAULT_PRIMARY;
+  const secondaryColor = appearance?.secondaryColor || DEFAULT_SECONDARY;
+  const favicon = appearance?.faviconUrl;
+
+  const darkThemeMeta = document.querySelector(
+    'meta[name="theme-color"][media="(prefers-color-scheme: dark)"]',
+  );
+  darkThemeMeta?.setAttribute("content", primaryColor);
+
+  const lightThemeMeta = document.querySelector(
+    'meta[name="theme-color"][media="(prefers-color-scheme: light)"]',
+  );
+  lightThemeMeta?.setAttribute("content", secondaryColor);
+
+  const icon32 = document.querySelector(
+    'link[rel="icon"][sizes="32x32"]',
+  ) as HTMLLinkElement | null;
+  const icon16 = document.querySelector(
+    'link[rel="icon"][sizes="16x16"]',
+  ) as HTMLLinkElement | null;
+
+  if (favicon) {
+    icon32?.setAttribute("href", favicon);
+    icon16?.setAttribute("href", favicon);
+    return;
+  }
+
+  icon32?.setAttribute("href", DEFAULT_FAVICON_32);
+  icon16?.setAttribute("href", DEFAULT_FAVICON_16);
+}

--- a/apps/client/src/lib/branding.ts
+++ b/apps/client/src/lib/branding.ts
@@ -1,4 +1,5 @@
 import { IWorkspaceSettings } from "@/features/workspace/types/workspace.types.ts";
+import { getFileUrl } from "@/lib/config.ts";
 
 const DEFAULT_PRIMARY = "#1f1f1f";
 
@@ -62,8 +63,9 @@ export function applyWorkspaceBranding(settings?: IWorkspaceSettings) {
   ) as HTMLLinkElement | null;
 
   if (favicon) {
-    icon32?.setAttribute("href", favicon);
-    icon16?.setAttribute("href", favicon);
+    const faviconFullUrl = getFileUrl(favicon);
+    icon32?.setAttribute("href", faviconFullUrl);
+    icon16?.setAttribute("href", faviconFullUrl);
     return;
   }
 

--- a/apps/client/src/lib/branding.ts
+++ b/apps/client/src/lib/branding.ts
@@ -6,10 +6,40 @@ const DEFAULT_FAVICON_32 = "/favicon-32x32.png";
 const DEFAULT_FAVICON_16 = "/favicon-16x16.png";
 
 export function applyWorkspaceBranding(settings?: IWorkspaceSettings) {
+  const root = document.documentElement;
   const appearance = settings?.appearance;
   const primaryColor = appearance?.primaryColor || DEFAULT_PRIMARY;
   const secondaryColor = appearance?.secondaryColor || DEFAULT_SECONDARY;
   const favicon = appearance?.faviconUrl;
+
+  // Mantine runtime variables (applies to buttons, badges, focus rings, etc.)
+  root.style.setProperty("--mantine-primary-color-filled", primaryColor);
+  root.style.setProperty(
+    "--mantine-primary-color-filled-hover",
+    `color-mix(in srgb, ${primaryColor} 88%, black)`,
+  );
+  root.style.setProperty(
+    "--mantine-primary-color-light",
+    `color-mix(in srgb, ${primaryColor} 14%, transparent)`,
+  );
+  root.style.setProperty(
+    "--mantine-primary-color-light-hover",
+    `color-mix(in srgb, ${primaryColor} 20%, transparent)`,
+  );
+  root.style.setProperty("--mantine-primary-color-light-color", primaryColor);
+  root.style.setProperty(
+    "--mantine-primary-color-outline",
+    `color-mix(in srgb, ${primaryColor} 92%, white)`,
+  );
+  root.style.setProperty("--mantine-primary-color-outline-hover", secondaryColor);
+
+  // Keep blue palette aligned with selected primary color for components explicitly using `color="blue"`.
+  root.style.setProperty("--mantine-color-blue-filled", primaryColor);
+  root.style.setProperty(
+    "--mantine-color-blue-filled-hover",
+    `color-mix(in srgb, ${primaryColor} 88%, black)`,
+  );
+  root.style.setProperty("--mantine-color-blue-light-color", primaryColor);
 
   const darkThemeMeta = document.querySelector(
     'meta[name="theme-color"][media="(prefers-color-scheme: dark)"]',

--- a/apps/client/src/lib/config.ts
+++ b/apps/client/src/lib/config.ts
@@ -10,7 +10,7 @@ declare global {
 }
 
 export function getAppName(): string {
-  return "Forkmost";
+  return getConfigValue("APP_NAME", "Forkmost");
 }
 
 export function getAppUrl(): string {
@@ -64,7 +64,7 @@ export function getSpaceGraphUrl(spaceSlug: string) {
 export function getFileUrl(src: string) {
   if (!src) return src;
   if (src.startsWith("http")) return src;
-  
+
   if (src.startsWith("/api/")) {
     // Remove the '/api' prefix
     return getBackendUrl() + src.substring(4);

--- a/apps/client/src/pages/settings/workspace/workspace-settings.tsx
+++ b/apps/client/src/pages/settings/workspace/workspace-settings.tsx
@@ -1,6 +1,7 @@
 import SettingsTitle from "@/components/settings/settings-title.tsx";
 import WorkspaceNameForm from "@/features/workspace/components/settings/components/workspace-name-form";
 import WorkspaceIcon from "@/features/workspace/components/settings/components/workspace-icon.tsx";
+import WorkspaceBrandingForm from "@/features/workspace/components/settings/components/workspace-branding-form.tsx";
 import { useTranslation } from "react-i18next";
 import { getAppName } from "@/lib/config.ts";
 import { Helmet } from "react-helmet-async";
@@ -15,6 +16,7 @@ export default function WorkspaceSettings() {
       <SettingsTitle title={t("General")} />
       <WorkspaceIcon />
       <WorkspaceNameForm />
+      <WorkspaceBrandingForm />
     </>
   );
 }

--- a/apps/client/vite.config.ts
+++ b/apps/client/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig(({ mode }) => {
     BILLING_TRIAL_DAYS,
     POSTHOG_HOST,
     POSTHOG_KEY,
+    APP_NAME,
     VITE_HOST,
     VITE_PORT,
     VITE_ALLOWED_HOSTS,
@@ -24,6 +25,7 @@ export default defineConfig(({ mode }) => {
   return {
     define: {
       "process.env": {
+        APP_NAME,
         APP_URL,
         FILE_UPLOAD_SIZE_LIMIT,
         FILE_IMPORT_SIZE_LIMIT,
@@ -61,7 +63,9 @@ export default defineConfig(({ mode }) => {
     server: {
       host: VITE_HOST || undefined,
       port: VITE_PORT ? parseInt(VITE_PORT, 10) : undefined,
-      allowedHosts: VITE_ALLOWED_HOSTS ? VITE_ALLOWED_HOSTS.split(",") : undefined,
+      allowedHosts: VITE_ALLOWED_HOSTS
+        ? VITE_ALLOWED_HOSTS.split(",")
+        : undefined,
       proxy: {
         "/api": {
           target: APP_URL,

--- a/apps/server/src/core/attachment/attachment.constants.ts
+++ b/apps/server/src/core/attachment/attachment.constants.ts
@@ -2,12 +2,17 @@ export enum AttachmentType {
   Avatar = 'avatar',
   WorkspaceIcon = 'workspace-icon',
   SpaceIcon = 'space-icon',
+  WorkspaceFavicon = 'workspace-favicon',
   File = 'file',
 }
 
 export const validImageExtensions = ['.jpg', '.png', '.jpeg', '.webp'];
 export const MAX_AVATAR_SIZE = '10MB';
 export const MAX_AVATAR_SIZE_BYTES = 10 * 1024 * 1024;
+
+export const MAX_FAVICON_SIZE = '10KB';
+export const MAX_FAVICON_SIZE_BYTES = 10 * 1024;
+export const validFaviconExtensions = ['.png', '.ico', '.svg', '.webp'];
 
 export const inlineFileExtensions = [
   '.jpg',

--- a/apps/server/src/core/attachment/attachment.constants.ts
+++ b/apps/server/src/core/attachment/attachment.constants.ts
@@ -10,7 +10,7 @@ export const validImageExtensions = ['.jpg', '.png', '.jpeg', '.webp'];
 export const MAX_AVATAR_SIZE = '10MB';
 export const MAX_AVATAR_SIZE_BYTES = 10 * 1024 * 1024;
 
-export const MAX_FAVICON_SIZE = '10KB';
+export const MAX_FAVICON_SIZE = '10KB'; // Need to be changed in the frontend too (client/src/features/workspace/components/settings/workspace-branding-form.ts)
 export const MAX_FAVICON_SIZE_BYTES = 10 * 1024;
 export const validFaviconExtensions = ['.png', '.ico', '.svg', '.webp'];
 

--- a/apps/server/src/core/attachment/attachment.controller.ts
+++ b/apps/server/src/core/attachment/attachment.controller.ts
@@ -35,6 +35,7 @@ import {
   AttachmentType,
   inlineFileExtensions,
   MAX_AVATAR_SIZE,
+  MAX_FAVICON_SIZE_BYTES,
 } from './attachment.constants';
 import {
   SpaceCaslAction,
@@ -61,6 +62,8 @@ import {
   AUDIT_SERVICE,
   IAuditService,
 } from '../../integrations/audit/audit.service';
+import { Public } from '../../common/decorators/public.decorator';
+import { UserRole } from '../../common/helpers/types/permission';
 
 @Controller()
 export class AttachmentController {
@@ -285,9 +288,13 @@ export class AttachmentController {
     const spaceId = file.fields?.spaceId?.value;
 
     if (attachmentType === AttachmentType.Avatar) {
-      const oidcProvider = await this.authProviderRepo.findOidcProvider(workspace.id);
+      const oidcProvider = await this.authProviderRepo.findOidcProvider(
+        workspace.id,
+      );
       if (oidcProvider?.oidcAvatarAttribute) {
-        throw new ForbiddenException('Avatar is managed by your identity provider');
+        throw new ForbiddenException(
+          'Avatar is managed by your identity provider',
+        );
       }
     }
 
@@ -343,6 +350,60 @@ export class AttachmentController {
     }
   }
 
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  @Post('attachments/upload-favicon')
+  @UseInterceptors(FileInterceptor)
+  async uploadFavicon(
+    @Req() req: any,
+    @Res() res: FastifyReply,
+    @AuthUser() user: User,
+    @AuthWorkspace() workspace: Workspace,
+  ) {
+    const maxFileSize = MAX_FAVICON_SIZE_BYTES;
+
+    let file = null;
+    try {
+      file = await req.file({
+        limits: { fileSize: maxFileSize, fields: 3, files: 1 },
+      });
+    } catch (err: any) {
+      if (err?.statusCode === 413) {
+        throw new BadRequestException(
+          `File too large. Exceeds the 100KB limit`,
+        );
+      }
+    }
+
+    if (!file) {
+      throw new BadRequestException('Invalid file upload');
+    }
+
+    const ability = this.workspaceAbility.createForUser(user, workspace);
+    if (
+      ability.cannot(WorkspaceCaslAction.Manage, WorkspaceCaslSubject.Settings)
+    ) {
+      throw new ForbiddenException();
+    }
+
+    if (user.role !== UserRole.OWNER) {
+      throw new ForbiddenException('Only workspace owners can update branding');
+    }
+
+    try {
+      const result = await this.attachmentService.uploadWorkspaceFavicon(
+        file,
+        user.id,
+        workspace.id,
+      );
+
+      return res.send({ faviconUrl: result.faviconUrl });
+    } catch (err: any) {
+      this.logger.error(err);
+      throw new BadRequestException('Error processing favicon upload.');
+    }
+  }
+
   @Get('attachments/img/:attachmentType/:fileName')
   async getLogoOrAvatar(
     @Res() res: FastifyReply,
@@ -373,6 +434,40 @@ export class AttachmentController {
       return res.send(fileStream);
     } catch (err) {
       // this.logger.error(err);
+      throw new NotFoundException('File not found');
+    }
+  }
+
+  @Public()
+  @Get('attachments/favicon/:workspaceId/:fileName')
+  async getFavicon(
+    @Res() res: FastifyReply,
+    @Param('workspaceId') workspaceId: string,
+    @Param('fileName') fileName?: string,
+  ) {
+    if (!isValidUUID(workspaceId)) {
+      throw new BadRequestException('Invalid workspace id');
+    }
+
+    if (!fileName) {
+      throw new NotFoundException('File not found');
+    }
+
+    const filenameWithoutExt = path.basename(fileName, path.extname(fileName));
+    if (!isValidUUID(filenameWithoutExt)) {
+      throw new BadRequestException('Invalid file name');
+    }
+
+    const filePath = `${getAttachmentFolderPath(AttachmentType.WorkspaceFavicon, workspaceId)}/${fileName}`;
+
+    try {
+      const fileStream = await this.storageService.readStream(filePath);
+      res.headers({
+        'Content-Type': getMimeType(filePath),
+        'Cache-Control': 'public, max-age=86400',
+      });
+      return res.send(fileStream);
+    } catch (err) {
       throw new NotFoundException('File not found');
     }
   }
@@ -417,9 +512,13 @@ export class AttachmentController {
 
     // remove current user avatar
     if (type === AttachmentType.Avatar) {
-      const oidcProvider = await this.authProviderRepo.findOidcProvider(workspace.id);
+      const oidcProvider = await this.authProviderRepo.findOidcProvider(
+        workspace.id,
+      );
       if (oidcProvider?.oidcAvatarAttribute) {
-        throw new ForbiddenException('Avatar is managed by your identity provider');
+        throw new ForbiddenException(
+          'Avatar is managed by your identity provider',
+        );
       }
 
       await this.attachmentService.removeUserAvatar(user);
@@ -457,6 +556,28 @@ export class AttachmentController {
         throw new ForbiddenException();
       }
       await this.attachmentService.removeWorkspaceIcon(workspace);
+      return;
+    }
+
+    // remove workspace favicon
+    if (type === AttachmentType.WorkspaceFavicon) {
+      const ability = this.workspaceAbility.createForUser(user, workspace);
+      if (
+        ability.cannot(
+          WorkspaceCaslAction.Manage,
+          WorkspaceCaslSubject.Settings,
+        )
+      ) {
+        throw new ForbiddenException();
+      }
+
+      if (user.role !== UserRole.OWNER) {
+        throw new ForbiddenException(
+          'Only workspace owners can update branding',
+        );
+      }
+
+      await this.attachmentService.removeWorkspaceFavicon(workspace.id);
       return;
     }
   }

--- a/apps/server/src/core/attachment/attachment.controller.ts
+++ b/apps/server/src/core/attachment/attachment.controller.ts
@@ -370,7 +370,7 @@ export class AttachmentController {
     } catch (err: any) {
       if (err?.statusCode === 413) {
         throw new BadRequestException(
-          `File too large. Exceeds the 100KB limit`,
+          `File too large. Exceeds the ${maxFileSize / 1024}KB limit`,
         );
       }
     }
@@ -439,37 +439,33 @@ export class AttachmentController {
   }
 
   @Public()
-  @Get('attachments/favicon/:workspaceId/:fileName')
+  @Get('attachments/favicon/:workspaceId')
   async getFavicon(
     @Res() res: FastifyReply,
     @Param('workspaceId') workspaceId: string,
-    @Param('fileName') fileName?: string,
   ) {
     if (!isValidUUID(workspaceId)) {
       throw new BadRequestException('Invalid workspace id');
     }
 
-    if (!fileName) {
-      throw new NotFoundException('File not found');
+    // Try accepted favicon filenames
+    const commonExtensions = ['.ico', '.png', '.webp', '.svg'];
+    for (const ext of commonExtensions) {
+      const filePath = `${getAttachmentFolderPath(AttachmentType.WorkspaceFavicon, workspaceId)}/favicon${ext}`;
+
+      try {
+        const fileStream = await this.storageService.readStream(filePath);
+        res.headers({
+          'Content-Type': getMimeType(filePath),
+          'Cache-Control': 'public, max-age=86400',
+        });
+        return res.send(fileStream);
+      } catch (err) {
+        // Continue to next file if this one doesn't exist
+      }
     }
 
-    const filenameWithoutExt = path.basename(fileName, path.extname(fileName));
-    if (!isValidUUID(filenameWithoutExt)) {
-      throw new BadRequestException('Invalid file name');
-    }
-
-    const filePath = `${getAttachmentFolderPath(AttachmentType.WorkspaceFavicon, workspaceId)}/${fileName}`;
-
-    try {
-      const fileStream = await this.storageService.readStream(filePath);
-      res.headers({
-        'Content-Type': getMimeType(filePath),
-        'Cache-Control': 'public, max-age=86400',
-      });
-      return res.send(fileStream);
-    } catch (err) {
-      throw new NotFoundException('File not found');
-    }
+    throw new NotFoundException('File not found');
   }
 
   @UseGuards(JwtAuthGuard)

--- a/apps/server/src/core/attachment/attachment.utils.ts
+++ b/apps/server/src/core/attachment/attachment.utils.ts
@@ -69,6 +69,8 @@ export function getAttachmentFolderPath(
       return `${workspaceId}/workspace-logos`;
     case AttachmentType.SpaceIcon:
       return `${workspaceId}/space-logos`;
+    case AttachmentType.WorkspaceFavicon:
+      return `${workspaceId}/workspace-favicon`;
     case AttachmentType.File:
       return `${workspaceId}/files`;
     default:

--- a/apps/server/src/core/attachment/dto/attachment.dto.ts
+++ b/apps/server/src/core/attachment/dto/attachment.dto.ts
@@ -13,6 +13,7 @@ export class RemoveIconDto {
     AttachmentType.Avatar,
     AttachmentType.SpaceIcon,
     AttachmentType.WorkspaceIcon,
+    AttachmentType.WorkspaceFavicon,
   ])
   @IsNotEmpty()
   type: AttachmentType;

--- a/apps/server/src/core/attachment/services/attachment.service.ts
+++ b/apps/server/src/core/attachment/services/attachment.service.ts
@@ -480,9 +480,9 @@ export class AttachmentService {
     const oldFaviconUrl =
       (workspace?.settings as any)?.appearance?.faviconUrl ?? null;
 
-    preparedFile.fileName = uuid4() + preparedFile.fileExtension;
+    preparedFile.fileName = `favicon${preparedFile.fileExtension}`;
     const filePath = `${getAttachmentFolderPath(AttachmentType.WorkspaceFavicon, workspaceId)}/${preparedFile.fileName}`;
-    const faviconUrl = `/api/attachments/favicon/${workspaceId}/${preparedFile.fileName}`;
+    const faviconUrl = `/api/attachments/favicon/${workspaceId}`;
 
     await this.uploadToDrive(filePath, preparedFile.buffer);
 
@@ -511,12 +511,15 @@ export class AttachmentService {
       throw new BadRequestException('Failed to upload favicon');
     }
 
-    if (oldFaviconUrl && !oldFaviconUrl.toLowerCase().startsWith('http')) {
-      // Extract filename from stored URL path like /api/attachments/favicon/{workspaceId}/{fileName}
-      const oldFileName = oldFaviconUrl.split('/').pop();
-      if (oldFileName) {
-        const oldFilePath = `${getAttachmentFolderPath(AttachmentType.WorkspaceFavicon, workspaceId)}/${oldFileName}`;
-        await this.deleteRedundantFile(oldFilePath);
+    if (oldFaviconUrl) {
+      const commonExtensions = ['.ico', '.png', '.webp', '.svg'];
+      for (const ext of commonExtensions) {
+        try {
+          const oldFilePath = `${getAttachmentFolderPath(AttachmentType.WorkspaceFavicon, workspaceId)}/favicon${ext}`;
+          await this.deleteRedundantFile(oldFilePath);
+        } catch {
+          // Ignore errors if file doesn't exist
+        }
       }
     }
 
@@ -528,12 +531,16 @@ export class AttachmentService {
     const faviconUrl =
       (workspace?.settings as any)?.appearance?.faviconUrl ?? null;
 
-    if (faviconUrl && !faviconUrl.toLowerCase().startsWith('http')) {
-      // Extract filename from stored URL path like /api/attachments/favicon/{workspaceId}/{fileName}
-      const fileName = faviconUrl.split('/').pop();
-      if (fileName) {
-        const filePath = `${getAttachmentFolderPath(AttachmentType.WorkspaceFavicon, workspaceId)}/${fileName}`;
-        await this.deleteRedundantFile(filePath);
+    if (faviconUrl) {
+      // Deleting favicon with accepted file names
+      const commonExtensions = ['.ico', '.png', '.webp', '.svg'];
+      for (const ext of commonExtensions) {
+        try {
+          const filePath = `${getAttachmentFolderPath(AttachmentType.WorkspaceFavicon, workspaceId)}/favicon${ext}`;
+          await this.deleteRedundantFile(filePath);
+        } catch {
+          // Ignore errors if file doesn't exist
+        }
       }
     }
 

--- a/apps/server/src/core/attachment/services/attachment.service.ts
+++ b/apps/server/src/core/attachment/services/attachment.service.ts
@@ -16,7 +16,13 @@ import {
 import { v4 as uuid4, v7 as uuid7 } from 'uuid';
 import { createHash } from 'crypto';
 import { AttachmentRepo } from '@docmost/db/repos/attachment/attachment.repo';
-import { AttachmentType, validImageExtensions } from '../attachment.constants';
+import {
+  AttachmentType,
+  validImageExtensions,
+  validFaviconExtensions,
+  MAX_FAVICON_SIZE,
+  MAX_FAVICON_SIZE_BYTES,
+} from '../attachment.constants';
 import { KyselyDB, KyselyTransaction } from '@docmost/db/types/kysely.types';
 import { Attachment, User, Workspace } from '@docmost/db/types/entity.types';
 import { InjectKysely } from 'nestjs-kysely';
@@ -40,7 +46,7 @@ export class AttachmentService {
     private readonly spaceRepo: SpaceRepo,
     @InjectKysely() private readonly db: KyselyDB,
     @InjectQueue(QueueName.ATTACHMENT_QUEUE) private attachmentQueue: Queue,
-  ) { }
+  ) {}
 
   async uploadFile(opts: {
     filePromise: Promise<MultipartFile>;
@@ -172,10 +178,18 @@ export class AttachmentService {
       try {
         const currentFilePath = `${getAttachmentFolderPath(type, workspaceId)}/${oldFileName}`;
         const currentFile = await this.storageService.read(currentFilePath);
-        const currentBuffer = Buffer.isBuffer(currentFile) ? currentFile : Buffer.from(currentFile);
+        const currentBuffer = Buffer.isBuffer(currentFile)
+          ? currentFile
+          : Buffer.from(currentFile);
 
-        const newHash = createHash('sha256').update(preparedFile.buffer).digest('hex').substring(0, 16);
-        const currentHash = createHash('sha256').update(currentBuffer).digest('hex').substring(0, 16);
+        const newHash = createHash('sha256')
+          .update(preparedFile.buffer)
+          .digest('hex')
+          .substring(0, 16);
+        const currentHash = createHash('sha256')
+          .update(currentBuffer)
+          .digest('hex')
+          .substring(0, 16);
 
         if (newHash === currentHash) {
           return await this.attachmentRepo.findByFilePath(currentFilePath);
@@ -446,5 +460,87 @@ export class AttachmentService {
     }
 
     await this.workspaceRepo.updateWorkspace({ logo: null }, workspace.id);
+  }
+
+  async uploadWorkspaceFavicon(
+    filePromise: Promise<MultipartFile>,
+    userId: string,
+    workspaceId: string,
+  ): Promise<{ attachment: Attachment; faviconUrl: string }> {
+    const preparedFile: PreparedFile = await prepareFile(filePromise);
+    validateFileType(preparedFile.fileExtension, validFaviconExtensions);
+
+    if (preparedFile.fileSize > MAX_FAVICON_SIZE_BYTES) {
+      throw new BadRequestException(
+        `File too large. Exceeds the ${MAX_FAVICON_SIZE} limit`,
+      );
+    }
+
+    const workspace = await this.workspaceRepo.findById(workspaceId);
+    const oldFaviconUrl =
+      (workspace?.settings as any)?.appearance?.faviconUrl ?? null;
+
+    preparedFile.fileName = uuid4() + preparedFile.fileExtension;
+    const filePath = `${getAttachmentFolderPath(AttachmentType.WorkspaceFavicon, workspaceId)}/${preparedFile.fileName}`;
+    const faviconUrl = `/api/attachments/favicon/${workspaceId}/${preparedFile.fileName}`;
+
+    await this.uploadToDrive(filePath, preparedFile.buffer);
+
+    let attachment: Attachment = null;
+
+    try {
+      await executeTx(this.db, async (trx) => {
+        attachment = await this.saveAttachment({
+          preparedFile,
+          filePath,
+          type: AttachmentType.WorkspaceFavicon,
+          userId,
+          workspaceId,
+          trx,
+        });
+
+        await this.workspaceRepo.updateAppearanceSettings(
+          workspaceId,
+          'faviconUrl',
+          faviconUrl,
+          trx,
+        );
+      });
+    } catch (err) {
+      await this.deleteRedundantFile(filePath);
+      throw new BadRequestException('Failed to upload favicon');
+    }
+
+    if (oldFaviconUrl && !oldFaviconUrl.toLowerCase().startsWith('http')) {
+      // Extract filename from stored URL path like /api/attachments/favicon/{workspaceId}/{fileName}
+      const oldFileName = oldFaviconUrl.split('/').pop();
+      if (oldFileName) {
+        const oldFilePath = `${getAttachmentFolderPath(AttachmentType.WorkspaceFavicon, workspaceId)}/${oldFileName}`;
+        await this.deleteRedundantFile(oldFilePath);
+      }
+    }
+
+    return { attachment, faviconUrl };
+  }
+
+  async removeWorkspaceFavicon(workspaceId: string) {
+    const workspace = await this.workspaceRepo.findById(workspaceId);
+    const faviconUrl =
+      (workspace?.settings as any)?.appearance?.faviconUrl ?? null;
+
+    if (faviconUrl && !faviconUrl.toLowerCase().startsWith('http')) {
+      // Extract filename from stored URL path like /api/attachments/favicon/{workspaceId}/{fileName}
+      const fileName = faviconUrl.split('/').pop();
+      if (fileName) {
+        const filePath = `${getAttachmentFolderPath(AttachmentType.WorkspaceFavicon, workspaceId)}/${fileName}`;
+        await this.deleteRedundantFile(filePath);
+      }
+    }
+
+    await this.workspaceRepo.updateAppearanceSettings(
+      workspaceId,
+      'faviconUrl',
+      null as any,
+    );
   }
 }

--- a/apps/server/src/core/workspace/controllers/workspace.controller.ts
+++ b/apps/server/src/core/workspace/controllers/workspace.controller.ts
@@ -37,6 +37,7 @@ import { CheckHostnameDto } from '../dto/check-hostname.dto';
 import { RemoveWorkspaceUserDto } from '../dto/remove-workspace-user.dto';
 import { ChangeWorkspaceMemberPasswordDto } from '../../auth/dto/change-password.dto';
 import { WorkspaceRepo } from '@docmost/db/repos/workspace/workspace.repo';
+import { UserRole } from '../../../common/helpers/types/permission';
 
 @UseGuards(JwtAuthGuard)
 @Controller('workspace')
@@ -93,6 +94,15 @@ export class WorkspaceController {
       ability.cannot(WorkspaceCaslAction.Manage, WorkspaceCaslSubject.Settings)
     ) {
       throw new ForbiddenException();
+    }
+
+    const hasAppearanceUpdate =
+      typeof dto.primaryColor !== 'undefined' ||
+      typeof dto.secondaryColor !== 'undefined' ||
+      typeof dto.faviconUrl !== 'undefined';
+
+    if (hasAppearanceUpdate && user.role !== UserRole.OWNER) {
+      throw new ForbiddenException('Only workspace owners can update branding');
     }
 
     const updatedWorkspace = await this.workspaceService.update(

--- a/apps/server/src/core/workspace/controllers/workspace.controller.ts
+++ b/apps/server/src/core/workspace/controllers/workspace.controller.ts
@@ -98,7 +98,6 @@ export class WorkspaceController {
 
     const hasAppearanceUpdate =
       typeof dto.primaryColor !== 'undefined' ||
-      typeof dto.secondaryColor !== 'undefined' ||
       typeof dto.faviconUrl !== 'undefined';
 
     if (hasAppearanceUpdate && user.role !== UserRole.OWNER) {
@@ -135,7 +134,11 @@ export class WorkspaceController {
       throw new ForbiddenException();
     }
 
-    return this.workspaceService.getWorkspaceUsers(user, workspace.id, pagination);
+    return this.workspaceService.getWorkspaceUsers(
+      user,
+      workspace.id,
+      pagination,
+    );
   }
 
   @HttpCode(HttpStatus.OK)
@@ -184,11 +187,7 @@ export class WorkspaceController {
       throw new ForbiddenException();
     }
 
-    await this.workspaceService.changeUserPassword(
-      dto,
-      user.id,
-      workspace.id,
-    );
+    await this.workspaceService.changeUserPassword(dto, user.id, workspace.id);
   }
 
   @HttpCode(HttpStatus.OK)

--- a/apps/server/src/core/workspace/controllers/workspace.controller.ts
+++ b/apps/server/src/core/workspace/controllers/workspace.controller.ts
@@ -96,11 +96,10 @@ export class WorkspaceController {
       throw new ForbiddenException();
     }
 
-    const hasAppearanceUpdate =
-      typeof dto.primaryColor !== 'undefined' ||
-      typeof dto.faviconUrl !== 'undefined';
-
-    if (hasAppearanceUpdate && user.role !== UserRole.OWNER) {
+    if (
+      typeof dto.primaryColor !== 'undefined' &&
+      user.role !== UserRole.OWNER
+    ) {
       throw new ForbiddenException('Only workspace owners can update branding');
     }
 

--- a/apps/server/src/core/workspace/dto/update-workspace.dto.ts
+++ b/apps/server/src/core/workspace/dto/update-workspace.dto.ts
@@ -7,7 +7,6 @@ import {
   IsInt,
   IsOptional,
   IsString,
-  IsUrl,
   Min,
 } from 'class-validator';
 
@@ -56,11 +55,4 @@ export class UpdateWorkspaceDto extends PartialType(CreateWorkspaceDto) {
   @IsOptional()
   @IsHexColor()
   primaryColor: string;
-
-  @IsOptional()
-  @IsUrl({
-    require_tld: false,
-    require_protocol: true,
-  })
-  faviconUrl: string;
 }

--- a/apps/server/src/core/workspace/dto/update-workspace.dto.ts
+++ b/apps/server/src/core/workspace/dto/update-workspace.dto.ts
@@ -3,9 +3,11 @@ import { CreateWorkspaceDto } from './create-workspace.dto';
 import {
   IsArray,
   IsBoolean,
+  IsHexColor,
   IsInt,
   IsOptional,
   IsString,
+  IsUrl,
   Min,
 } from 'class-validator';
 
@@ -50,4 +52,19 @@ export class UpdateWorkspaceDto extends PartialType(CreateWorkspaceDto) {
   @IsInt()
   @Min(1)
   trashRetentionDays: number;
+
+  @IsOptional()
+  @IsHexColor()
+  primaryColor: string;
+
+  @IsOptional()
+  @IsHexColor()
+  secondaryColor: string;
+
+  @IsOptional()
+  @IsUrl({
+    require_tld: false,
+    require_protocol: true,
+  })
+  faviconUrl: string;
 }

--- a/apps/server/src/core/workspace/dto/update-workspace.dto.ts
+++ b/apps/server/src/core/workspace/dto/update-workspace.dto.ts
@@ -58,10 +58,6 @@ export class UpdateWorkspaceDto extends PartialType(CreateWorkspaceDto) {
   primaryColor: string;
 
   @IsOptional()
-  @IsHexColor()
-  secondaryColor: string;
-
-  @IsOptional()
   @IsUrl({
     require_tld: false,
     require_protocol: true,

--- a/apps/server/src/core/workspace/services/workspace.service.ts
+++ b/apps/server/src/core/workspace/services/workspace.service.ts
@@ -472,28 +472,12 @@ export class WorkspaceService {
         );
       }
 
-      if (typeof updateWorkspaceDto.faviconUrl !== 'undefined') {
-        const prev = settingsBefore?.appearance?.faviconUrl ?? null;
-        if (prev !== updateWorkspaceDto.faviconUrl) {
-          before.faviconUrl = prev;
-          after.faviconUrl = updateWorkspaceDto.faviconUrl;
-        }
-        await this.workspaceRepo.updateAppearanceSettings(
-          workspaceId,
-          'faviconUrl',
-          updateWorkspaceDto.faviconUrl,
-          trx,
-        );
-      }
-
       delete updateWorkspaceDto.restrictApiToAdmins;
       delete updateWorkspaceDto.aiSearch;
       delete updateWorkspaceDto.generativeAi;
       delete updateWorkspaceDto.disablePublicSharing;
       delete updateWorkspaceDto.mcpEnabled;
       delete updateWorkspaceDto.primaryColor;
-
-      delete updateWorkspaceDto.faviconUrl;
 
       await this.workspaceRepo.updateWorkspace(
         updateWorkspaceDto,

--- a/apps/server/src/core/workspace/services/workspace.service.ts
+++ b/apps/server/src/core/workspace/services/workspace.service.ts
@@ -41,7 +41,10 @@ import {
   generateRandomSuffixNumbers,
   hashPassword,
 } from '../../../common/helpers';
-import { ChangePasswordDto, ChangeWorkspaceMemberPasswordDto } from '../../auth/dto/change-password.dto';
+import {
+  ChangePasswordDto,
+  ChangeWorkspaceMemberPasswordDto,
+} from '../../auth/dto/change-password.dto';
 import ChangePasswordEmail from '@docmost/transactional/emails/change-password-email';
 import ChangeUserPasswordEmail from '@docmost/transactional/emails/change-user-password-email';
 import { MailService } from '../../../integrations/mail/mail.service';
@@ -96,7 +99,16 @@ export class WorkspaceService {
   async getWorkspacePublicData(workspaceId: string) {
     const workspace = await this.db
       .selectFrom('workspaces')
-      .select(['id', 'name', 'logo', 'hostname', 'enforceSso', 'settings', 'licenseKey', 'plan'])
+      .select([
+        'id',
+        'name',
+        'logo',
+        'hostname',
+        'enforceSso',
+        'settings',
+        'licenseKey',
+        'plan',
+      ])
       .select((eb) =>
         jsonArrayFrom(
           eb
@@ -460,20 +472,6 @@ export class WorkspaceService {
         );
       }
 
-      if (typeof updateWorkspaceDto.secondaryColor !== 'undefined') {
-        const prev = settingsBefore?.appearance?.secondaryColor ?? null;
-        if (prev !== updateWorkspaceDto.secondaryColor) {
-          before.secondaryColor = prev;
-          after.secondaryColor = updateWorkspaceDto.secondaryColor;
-        }
-        await this.workspaceRepo.updateAppearanceSettings(
-          workspaceId,
-          'secondaryColor',
-          updateWorkspaceDto.secondaryColor,
-          trx,
-        );
-      }
-
       if (typeof updateWorkspaceDto.faviconUrl !== 'undefined') {
         const prev = settingsBefore?.appearance?.faviconUrl ?? null;
         if (prev !== updateWorkspaceDto.faviconUrl) {
@@ -494,7 +492,7 @@ export class WorkspaceService {
       delete updateWorkspaceDto.disablePublicSharing;
       delete updateWorkspaceDto.mcpEnabled;
       delete updateWorkspaceDto.primaryColor;
-      delete updateWorkspaceDto.secondaryColor;
+
       delete updateWorkspaceDto.faviconUrl;
 
       await this.workspaceRepo.updateWorkspace(
@@ -528,13 +526,7 @@ export class WorkspaceService {
     });
 
     const columnChanges = diffAuditTrackedFields(
-      [
-        'name',
-        'logo',
-        'enforceSso',
-        'enforceMfa',
-        'emailDomains',
-      ],
+      ['name', 'logo', 'enforceSso', 'enforceMfa', 'emailDomains'],
       updateWorkspaceDto,
       workspaceBefore,
       workspace,
@@ -565,7 +557,11 @@ export class WorkspaceService {
     if (user.role === 'owner' || user.role === 'admin') {
       return this.userRepo.getUsersPaginated(workspaceId, pagination);
     }
-    return this.userRepo.getUsersInSpacesOfUser(workspaceId, user.id, pagination);
+    return this.userRepo.getUsersInSpacesOfUser(
+      workspaceId,
+      user.id,
+      pagination,
+    );
   }
 
   async updateWorkspaceUserRole(
@@ -870,9 +866,7 @@ export class WorkspaceService {
       throw new NotFoundException('User not found');
     }
 
-    if (
-      (actorUser.role === UserRole.ADMIN && user.role === UserRole.OWNER)
-    ) {
+    if (actorUser.role === UserRole.ADMIN && user.role === UserRole.OWNER) {
       throw new ForbiddenException();
     }
 
@@ -895,7 +889,10 @@ export class WorkspaceService {
       workspaceId,
     );
 
-    const emailTemplate = ChangeUserPasswordEmail({ username: user.name, actorUsername: actorUser.name });
+    const emailTemplate = ChangeUserPasswordEmail({
+      username: user.name,
+      actorUsername: actorUser.name,
+    });
     await this.mailService.sendToQueue({
       to: user.email,
       subject: 'Your password has been changed',

--- a/apps/server/src/core/workspace/services/workspace.service.ts
+++ b/apps/server/src/core/workspace/services/workspace.service.ts
@@ -96,7 +96,7 @@ export class WorkspaceService {
   async getWorkspacePublicData(workspaceId: string) {
     const workspace = await this.db
       .selectFrom('workspaces')
-      .select(['id', 'name', 'logo', 'hostname', 'enforceSso', 'licenseKey', 'plan'])
+      .select(['id', 'name', 'logo', 'hostname', 'enforceSso', 'settings', 'licenseKey', 'plan'])
       .select((eb) =>
         jsonArrayFrom(
           eb
@@ -446,11 +446,56 @@ export class WorkspaceService {
         );
       }
 
+      if (typeof updateWorkspaceDto.primaryColor !== 'undefined') {
+        const prev = settingsBefore?.appearance?.primaryColor ?? null;
+        if (prev !== updateWorkspaceDto.primaryColor) {
+          before.primaryColor = prev;
+          after.primaryColor = updateWorkspaceDto.primaryColor;
+        }
+        await this.workspaceRepo.updateAppearanceSettings(
+          workspaceId,
+          'primaryColor',
+          updateWorkspaceDto.primaryColor,
+          trx,
+        );
+      }
+
+      if (typeof updateWorkspaceDto.secondaryColor !== 'undefined') {
+        const prev = settingsBefore?.appearance?.secondaryColor ?? null;
+        if (prev !== updateWorkspaceDto.secondaryColor) {
+          before.secondaryColor = prev;
+          after.secondaryColor = updateWorkspaceDto.secondaryColor;
+        }
+        await this.workspaceRepo.updateAppearanceSettings(
+          workspaceId,
+          'secondaryColor',
+          updateWorkspaceDto.secondaryColor,
+          trx,
+        );
+      }
+
+      if (typeof updateWorkspaceDto.faviconUrl !== 'undefined') {
+        const prev = settingsBefore?.appearance?.faviconUrl ?? null;
+        if (prev !== updateWorkspaceDto.faviconUrl) {
+          before.faviconUrl = prev;
+          after.faviconUrl = updateWorkspaceDto.faviconUrl;
+        }
+        await this.workspaceRepo.updateAppearanceSettings(
+          workspaceId,
+          'faviconUrl',
+          updateWorkspaceDto.faviconUrl,
+          trx,
+        );
+      }
+
       delete updateWorkspaceDto.restrictApiToAdmins;
       delete updateWorkspaceDto.aiSearch;
       delete updateWorkspaceDto.generativeAi;
       delete updateWorkspaceDto.disablePublicSharing;
       delete updateWorkspaceDto.mcpEnabled;
+      delete updateWorkspaceDto.primaryColor;
+      delete updateWorkspaceDto.secondaryColor;
+      delete updateWorkspaceDto.faviconUrl;
 
       await this.workspaceRepo.updateWorkspace(
         updateWorkspaceDto,

--- a/apps/server/src/database/repos/workspace/workspace.repo.ts
+++ b/apps/server/src/database/repos/workspace/workspace.repo.ts
@@ -230,4 +230,24 @@ export class WorkspaceRepo {
       .executeTakeFirst();
   }
 
+  async updateAppearanceSettings(
+    workspaceId: string,
+    prefKey: string,
+    prefValue: string,
+    trx?: KyselyTransaction,
+  ) {
+    const db = dbOrTx(this.db, trx);
+    return db
+      .updateTable('workspaces')
+      .set({
+        settings: sql`COALESCE(settings, '{}'::jsonb)
+                || jsonb_build_object('appearance', COALESCE(settings->'appearance', '{}'::jsonb)
+                || jsonb_build_object('${sql.raw(prefKey)}', ${sql.lit(prefValue)}))`,
+        updatedAt: new Date(),
+      })
+      .where('id', '=', workspaceId)
+      .returning(this.baseFields)
+      .executeTakeFirst();
+  }
+
 }

--- a/apps/server/src/integrations/environment/environment.service.ts
+++ b/apps/server/src/integrations/environment/environment.service.ts
@@ -14,6 +14,10 @@ export class EnvironmentService {
     return this.getNodeEnv() === 'development';
   }
 
+  getAppName(): string {
+    return this.configService.get<string>('APP_NAME', 'Forkmost');
+  }
+
   getAppUrl(): string {
     const rawUrl =
       this.configService.get<string>('APP_URL') ||

--- a/apps/server/src/integrations/environment/environment.validation.ts
+++ b/apps/server/src/integrations/environment/environment.validation.ts
@@ -36,6 +36,10 @@ export class EnvironmentVariables {
   REDIS_URL: string;
 
   @IsOptional()
+  @IsString()
+  APP_NAME: string;
+
+  @IsOptional()
   @IsUrl({ protocols: ['http', 'https'], require_tld: false })
   APP_URL: string;
 

--- a/apps/server/src/integrations/static/static.module.ts
+++ b/apps/server/src/integrations/static/static.module.ts
@@ -33,6 +33,7 @@ export class StaticModule implements OnModuleInit {
 
       const configString = {
         ENV: this.environmentService.getNodeEnv(),
+        APP_NAME: this.environmentService.getAppName(),
         APP_URL: this.environmentService.getAppUrl(),
         CLOUD: this.environmentService.isCloud(),
         FILE_UPLOAD_SIZE_LIMIT:

--- a/docker_run_postgres.sh
+++ b/docker_run_postgres.sh
@@ -1,0 +1,8 @@
+docker run -d \
+  --name docmost-postgres \
+  -e POSTGRES_DB=docmost \
+  -e POSTGRES_USER=postgres \
+  -e POSTGRES_PASSWORD=password \
+  -p 5432:5432 \
+  -v docmost_postgres_data:/var/lib/postgresql/data \
+  postgres:16


### PR DESCRIPTION
This pull request introduces workspace-level branding customization, allowing workspace owners to set a primary theme color and favicon. The changes span both frontend and backend, providing a new settings UI, persisting branding options, and applying them dynamically throughout the app. Additionally, the app name can now be customized via environment variables and is consistently displayed in the UI.

This changes are useful for enterprise use.

**Workspace Branding Customization**

* Added a new `WorkspaceBrandingForm` component to the workspace settings page, allowing workspace owners to update the primary color and favicon URL for their workspace. These settings are validated and persisted, and only owners are permitted to make changes. [[1]](diffhunk://#diff-11e4917244989bbad7c1c9b62d33abac1dba75856eb71688b93b5b07c788968cR1-R84) [[2]](diffhunk://#diff-248e3b416d3d2b1babe1d7bcc7a4ff4d3c282c79d709fa80e6eff4205561b1fcR4) [[3]](diffhunk://#diff-248e3b416d3d2b1babe1d7bcc7a4ff4d3c282c79d709fa80e6eff4205561b1fcR19) [[4]](diffhunk://#diff-72f55ec7166369c1681d2eee2fcb2fb9ceb9333bf3e105ea66781168c210f74dR99-R106)
* Extended workspace types to include appearance settings (`primaryColor`, `faviconUrl`) and ensured these are available on the workspace object. [[1]](diffhunk://#diff-e5396d75ed78c8af113c71f779aa3c9073dd9273ff4beb03ad6473f8b387ed86R30-R38) [[2]](diffhunk://#diff-e5396d75ed78c8af113c71f779aa3c9073dd9273ff4beb03ad6473f8b387ed86R55-R59) [[3]](diffhunk://#diff-e5396d75ed78c8af113c71f779aa3c9073dd9273ff4beb03ad6473f8b387ed86R93)
* Implemented the `applyWorkspaceBranding` utility, which dynamically updates CSS variables and favicon links based on workspace settings, ensuring the UI reflects the selected branding.
* Integrated branding application into relevant components and providers to ensure branding is applied on authentication and workspace context changes. [[1]](diffhunk://#diff-993f01462379d0ef5732ff2c5846814be38c7e8f5f13a505476183e9f3bc1ba0L1-R17) [[2]](diffhunk://#diff-6327ab01ebd4530d8e19a57b8f6d5394a6d8d12dcaff47e528aa59e5f1d0cb5aR14) [[3]](diffhunk://#diff-6327ab01ebd4530d8e19a57b8f6d5394a6d8d12dcaff47e528aa59e5f1d0cb5aR54)

**App Name and UI Consistency**

* Introduced support for customizing the app name via the `APP_NAME` environment variable, with a fallback to "Forkmost". Updated all relevant UI components to use the new `getAppName` helper for consistent branding. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR4-R5) [[2]](diffhunk://#diff-15f2bb63fe1fdff3e1fc4f1d4e1073a523e077e84c94bee173bd8d032cdd7f5cL13-R13) [[3]](diffhunk://#diff-06dc04732984f8e0d7de4360e5d16837c7866f0c1b3e9e2e01078c4977d01df5L15-R15) [[4]](diffhunk://#diff-06dc04732984f8e0d7de4360e5d16837c7866f0c1b3e9e2e01078c4977d01df5L81-R81) [[5]](diffhunk://#diff-c60247aacac886dbf458fb2ee28ca238bffcfd3eb910d6de2c89568e0ecc236dR6-R16) [[6]](diffhunk://#diff-724bdbb532326f2627fd47c073abc1097face9216dab023d76c8514b92729b19R44) [[7]](diffhunk://#diff-724bdbb532326f2627fd47c073abc1097face9216dab023d76c8514b92729b19L130-R140)

**Backend Enforcement**

* Updated the backend workspace controller to enforce that only workspace owners can update branding-related fields (`primaryColor`, `faviconUrl`).

**Build and Environment Configuration**

* Updated the Vite configuration and `.env.example` to support the new `APP_NAME` environment variable, ensuring it is available at build time. [[1]](diffhunk://#diff-fdf593ea634bfa740bd01d195dfb868066843da1d1a0d060f636e8e3564e64dfR19) [[2]](diffhunk://#diff-fdf593ea634bfa740bd01d195dfb868066843da1d1a0d060f636e8e3564e64dfR28)

**Code Quality and Formatting**

* Improved code formatting and imports in several files for better readability and maintainability. [[1]](diffhunk://#diff-724bdbb532326f2627fd47c073abc1097face9216dab023d76c8514b92729b19L8-R8) [[2]](diffhunk://#diff-724bdbb532326f2627fd47c073abc1097face9216dab023d76c8514b92729b19L18-R21) [[3]](diffhunk://#diff-724bdbb532326f2627fd47c073abc1097face9216dab023d76c8514b92729b19L61-R71) [[4]](diffhunk://#diff-724bdbb532326f2627fd47c073abc1097face9216dab023d76c8514b92729b19L189-R195) [[5]](diffhunk://#diff-72f55ec7166369c1681d2eee2fcb2fb9ceb9333bf3e105ea66781168c210f74dL128-R141) [[6]](diffhunk://#diff-72f55ec7166369c1681d2eee2fcb2fb9ceb9333bf3e105ea66781168c210f74dL177-R190) [[7]](diffhunk://#diff-fdf593ea634bfa740bd01d195dfb868066843da1d1a0d060f636e8e3564e64dfL64-R68)
