### PR TITLE
Admin can disable public sharing

### DIFF
--- a/apps/client/src/features/page/components/header/page-header-menu.tsx
+++ b/apps/client/src/features/page/components/header/page-header-menu.tsx
@@ -44,6 +44,7 @@ import { PageStateSegmentedControl } from "@/features/user/components/page-state
 import MovePageModal from "@/features/page/components/move-page-modal.tsx";
 import { useTimeAgo } from "@/hooks/use-time-ago.tsx";
 import ShareModal from "@/features/share/components/share-modal.tsx";
+import { workspaceAtom } from "@/features/user/atoms/current-user-atom.ts";
 import {
   useWatchStatusQuery,
   useWatchPageMutation,
@@ -58,6 +59,9 @@ export default function PageHeaderMenu({ readOnly }: PageHeaderMenuProps) {
   const toggleAside = useToggleAside();
   const [yjsConnectionStatus] = useAtom(yjsConnectionStatusAtom);
   const [editor, setEditor] = useAtom(pageEditorAtom);
+  const [workspace] = useAtom(workspaceAtom);
+  const workspaceSharingDisabled =
+    workspace?.settings?.sharing?.disabled === true;
 
   useHotkeys(
     [
@@ -71,7 +75,10 @@ export default function PageHeaderMenu({ readOnly }: PageHeaderMenuProps) {
       [
         "mod+H",
         () => {
-          const event = new CustomEvent("openFindAndReplaceDialogFromEditor", {});
+          const event = new CustomEvent(
+            "openFindAndReplaceDialogFromEditor",
+            {},
+          );
           document.dispatchEvent(event);
         },
       ],
@@ -100,7 +107,7 @@ export default function PageHeaderMenu({ readOnly }: PageHeaderMenuProps) {
 
       {!readOnly && <PageStateSegmentedControl size="xs" />}
 
-      <ShareModal readOnly={readOnly} />
+      {!workspaceSharingDisabled && <ShareModal readOnly={readOnly} />}
 
       <Tooltip label={t("Comments")} openDelay={250} withArrow>
         <ActionIcon
@@ -186,12 +193,12 @@ function PageActionMenu({ readOnly }: PageActionMenuProps) {
   const openFindDialog = () => {
     const event = new CustomEvent("openFindDialogFromEditor", {});
     document.dispatchEvent(event);
-  }
+  };
 
   const openFindAndReplaceDialog = () => {
     const event = new CustomEvent("openFindAndReplaceDialogFromEditor", {});
     document.dispatchEvent(event);
-  }
+  };
 
   return (
     <>
@@ -249,7 +256,6 @@ function PageActionMenu({ readOnly }: PageActionMenuProps) {
           >
             {t("Replace")}
           </Menu.Item>
-
 
           {watchStatus?.watching ? (
             <Menu.Item

--- a/apps/client/src/pages/settings/shares/shares.tsx
+++ b/apps/client/src/pages/settings/shares/shares.tsx
@@ -3,12 +3,38 @@ import { Helmet } from "react-helmet-async";
 import { getAppName } from "@/lib/config.ts";
 import { useTranslation } from "react-i18next";
 import ShareList from "@/features/share/components/share-list.tsx";
-import { Alert, Text } from "@mantine/core";
-import { IconInfoCircle } from "@tabler/icons-react";
-import React from "react";
+import { Alert, Switch, Text, Divider, Group } from "@mantine/core";
+import { IconInfoCircle, IconWorld } from "@tabler/icons-react";
+import React, { useState } from "react";
+import { useAtom } from "jotai";
+import { workspaceAtom } from "@/features/user/atoms/current-user-atom.ts";
+import { updateWorkspace } from "@/features/workspace/services/workspace-service.ts";
+import { notifications } from "@mantine/notifications";
+import useUserRole from "@/hooks/use-user-role.tsx";
 
 export default function Shares() {
   const { t } = useTranslation();
+  const [isLoading, setIsLoading] = useState(false);
+  const [workspace, setWorkspace] = useAtom(workspaceAtom);
+  const { isAdmin } = useUserRole();
+  const sharingDisabled = workspace?.settings?.sharing?.disabled === true;
+
+  async function handleSharingToggle(checked: boolean) {
+    setIsLoading(true);
+    try {
+      const updatedWorkspace = await updateWorkspace({
+        disablePublicSharing: !checked,
+      });
+      setWorkspace(updatedWorkspace);
+      notifications.show({ message: t("Updated successfully") });
+    } catch (err) {
+      notifications.show({
+        message: t("Failed to update data"),
+        color: "red",
+      });
+    }
+    setIsLoading(false);
+  }
 
   return (
     <>
@@ -19,13 +45,63 @@ export default function Shares() {
       </Helmet>
       <SettingsTitle title={t("Public sharing")} />
 
-      <Alert variant="light" color="blue" icon={<IconInfoCircle />}>
-        {t(
-          "Publicly shared pages from spaces you are a member of will appear here",
-        )}
-      </Alert>
+      {isAdmin && (
+        <>
+          <div
+            style={{
+              display: "flex",
+              flexWrap: "wrap",
+              justifyContent: "space-between",
+              alignItems: "center",
+              gap: "1rem",
+            }}
+          >
+            <div style={{ flex: "1 1 300px", minWidth: 0 }}>
+              <Text fw={500}>{t("Allow public sharing")}</Text>
+              <Text size="sm" c="dimmed">
+                {t(
+                  "When enabled, users can share pages publicly via a link. When disabled, existing shared links become inactive.",
+                )}
+              </Text>
+            </div>
+            <div style={{ flex: "0 0 auto" }}>
+              <Switch
+                aria-label={t("Toggle public sharing")}
+                checked={!sharingDisabled}
+                onChange={(event) =>
+                  handleSharingToggle(event.currentTarget.checked)
+                }
+                disabled={isLoading || !isAdmin}
+              />
+            </div>
+          </div>
 
-      <ShareList />
+          <Divider my="lg" />
+        </>
+      )}
+
+      {sharingDisabled ? (
+        <Alert variant="light" color="red" icon={<IconWorld />}>
+          <Text fw={500} mb={4}>
+            {t("Public sharing is disabled")}
+          </Text>
+          <Text size="sm">
+            {t(
+              "Public sharing has been disabled at the workspace level. Existing shared links are inactive.",
+            )}
+          </Text>
+        </Alert>
+      ) : (
+        <>
+          <Alert variant="light" color="blue" icon={<IconInfoCircle />}>
+            {t(
+              "Publicly shared pages from spaces you are a member of will appear here",
+            )}
+          </Alert>
+
+          <ShareList />
+        </>
+      )}
     </>
   );
 }

--- a/apps/server/src/core/workspace/services/workspace.service.ts
+++ b/apps/server/src/core/workspace/services/workspace.service.ts
@@ -41,7 +41,10 @@ import {
   generateRandomSuffixNumbers,
   hashPassword,
 } from '../../../common/helpers';
-import { ChangePasswordDto, ChangeWorkspaceMemberPasswordDto } from '../../auth/dto/change-password.dto';
+import {
+  ChangePasswordDto,
+  ChangeWorkspaceMemberPasswordDto,
+} from '../../auth/dto/change-password.dto';
 import ChangePasswordEmail from '@docmost/transactional/emails/change-password-email';
 import ChangeUserPasswordEmail from '@docmost/transactional/emails/change-user-password-email';
 import { MailService } from '../../../integrations/mail/mail.service';
@@ -96,7 +99,15 @@ export class WorkspaceService {
   async getWorkspacePublicData(workspaceId: string) {
     const workspace = await this.db
       .selectFrom('workspaces')
-      .select(['id', 'name', 'logo', 'hostname', 'enforceSso', 'licenseKey', 'plan'])
+      .select([
+        'id',
+        'name',
+        'logo',
+        'hostname',
+        'enforceSso',
+        'licenseKey',
+        'plan',
+      ])
       .select((eb) =>
         jsonArrayFrom(
           eb
@@ -427,9 +438,6 @@ export class WorkspaceService {
           updateWorkspaceDto.disablePublicSharing,
           trx,
         );
-        if (updateWorkspaceDto.disablePublicSharing) {
-          await this.shareRepo.deleteByWorkspaceId(workspaceId, trx);
-        }
       }
 
       if (typeof updateWorkspaceDto.mcpEnabled !== 'undefined') {
@@ -483,13 +491,7 @@ export class WorkspaceService {
     });
 
     const columnChanges = diffAuditTrackedFields(
-      [
-        'name',
-        'logo',
-        'enforceSso',
-        'enforceMfa',
-        'emailDomains',
-      ],
+      ['name', 'logo', 'enforceSso', 'enforceMfa', 'emailDomains'],
       updateWorkspaceDto,
       workspaceBefore,
       workspace,
@@ -520,7 +522,11 @@ export class WorkspaceService {
     if (user.role === 'owner' || user.role === 'admin') {
       return this.userRepo.getUsersPaginated(workspaceId, pagination);
     }
-    return this.userRepo.getUsersInSpacesOfUser(workspaceId, user.id, pagination);
+    return this.userRepo.getUsersInSpacesOfUser(
+      workspaceId,
+      user.id,
+      pagination,
+    );
   }
 
   async updateWorkspaceUserRole(
@@ -825,9 +831,7 @@ export class WorkspaceService {
       throw new NotFoundException('User not found');
     }
 
-    if (
-      (actorUser.role === UserRole.ADMIN && user.role === UserRole.OWNER)
-    ) {
+    if (actorUser.role === UserRole.ADMIN && user.role === UserRole.OWNER) {
       throw new ForbiddenException();
     }
 
@@ -850,7 +854,10 @@ export class WorkspaceService {
       workspaceId,
     );
 
-    const emailTemplate = ChangeUserPasswordEmail({ username: user.name, actorUsername: actorUser.name });
+    const emailTemplate = ChangeUserPasswordEmail({
+      username: user.name,
+      actorUsername: actorUser.name,
+    });
     await this.mailService.sendToQueue({
       to: user.email,
       subject: 'Your password has been changed',

--- a/apps/server/src/database/types/entity.types.ts
+++ b/apps/server/src/database/types/entity.types.ts
@@ -58,11 +58,11 @@ export type Graph = {
   title: string | null;
   parentPageId: string | null;
   backlinks: GraphBacklink[];
-}
+};
 export type GraphBacklink = {
   sourcePageId: string;
   targetPageId: string;
-}
+};
 
 // SpaceMember
 export type SpaceMember = Selectable<SpaceMembers>;


### PR DESCRIPTION
Still with the goal of using Forkmost in a business setting, this small PR disables the ability for all users to publicly share a document.
- Add a toggle to disable public sharing
- Existing links become inactive (404) when disabled and become active again when sharing is re-enable
- Only admin and owners can activate/deactivate public sharing

---

This pull request introduces a workspace-level control to enable or disable public sharing of pages. Admin users can now toggle this setting from the workspace sharing settings page, which disables all existing shared links when turned off. The UI and backend have been updated to support this feature, and conditional rendering ensures non-admins and users in disabled workspaces see appropriate messaging. Some minor code style and formatting improvements are also included.

**Workspace Public Sharing Control**

- Added a toggle in the workspace sharing settings (`shares.tsx`) for admins to enable or disable public sharing. When disabled, all existing shared links become inactive, and an alert is shown to users. The toggle is disabled for non-admins. [[1]](diffhunk://#diff-9d7a2464696b2bc803460366355efb095b5ed07e65919c9a79cc554de1d8d002L6-R37) [[2]](diffhunk://#diff-9d7a2464696b2bc803460366355efb095b5ed07e65919c9a79cc554de1d8d002R48-R95) [[3]](diffhunk://#diff-9d7a2464696b2bc803460366355efb095b5ed07e65919c9a79cc554de1d8d002R104-R105)
- Updated the backend to support disabling public sharing at the workspace level by storing this setting and removing shared links when disabled.

**UI Logic & Conditional Rendering**

- Updated `PageHeaderMenu` to hide the share modal when public sharing is disabled at the workspace level. [[1]](diffhunk://#diff-9847f0e11dc3e069e6b4538e472015a46d12cbccc481184aae9b9a0dc936d3cdR47) [[2]](diffhunk://#diff-9847f0e11dc3e069e6b4538e472015a46d12cbccc481184aae9b9a0dc936d3cdR62-R64) [[3]](diffhunk://#diff-9847f0e11dc3e069e6b4538e472015a46d12cbccc481184aae9b9a0dc936d3cdL103-R110)
- Displayed an alert on the sharing settings page when public sharing is disabled, explaining the impact to users.

**Code Quality & Formatting**

- Improved code formatting and consistency in several server and type files, including better parameter formatting and type definitions. [[1]](diffhunk://#diff-0bb2db06e62328017245a6b199a586ef052d6d7f3283c8a7218700b4665632a4L44-R47) [[2]](diffhunk://#diff-0bb2db06e62328017245a6b199a586ef052d6d7f3283c8a7218700b4665632a4L99-R110) [[3]](diffhunk://#diff-0bb2db06e62328017245a6b199a586ef052d6d7f3283c8a7218700b4665632a4L486-R494) [[4]](diffhunk://#diff-0bb2db06e62328017245a6b199a586ef052d6d7f3283c8a7218700b4665632a4L523-R529) [[5]](diffhunk://#diff-0bb2db06e62328017245a6b199a586ef052d6d7f3283c8a7218700b4665632a4L828-R834) [[6]](diffhunk://#diff-0bb2db06e62328017245a6b199a586ef052d6d7f3283c8a7218700b4665632a4L853-R860) [[7]](diffhunk://#diff-cfd7ad0ab25618a6620653bd0578de81f2fd093faae6b97b7fc02e5a4288e4b5L61-R65)
- Minor UI code cleanups in `PageHeaderMenu` (e.g., consistent semicolon and bracket usage, whitespace fixes). [[1]](diffhunk://#diff-9847f0e11dc3e069e6b4538e472015a46d12cbccc481184aae9b9a0dc936d3cdL74-R81) [[2]](diffhunk://#diff-9847f0e11dc3e069e6b4538e472015a46d12cbccc481184aae9b9a0dc936d3cdL189-R201) [[3]](diffhunk://#diff-9847f0e11dc3e069e6b4538e472015a46d12cbccc481184aae9b9a0dc936d3cdL253)