### PR TITLE
fix(api-key): emit long-lived JWTs for "no expiration" keys

### DIFF
--- a/apps/server/src/core/auth/services/token.service.spec.ts
+++ b/apps/server/src/core/auth/services/token.service.spec.ts
@@ -1,12 +1,38 @@
+// `common/helpers` transitively imports `nanoid` (ESM-only), which the repo's
+// current jest config does not transform. We don't exercise any of those
+// helpers in this spec, so stub the barrel out to keep this file runnable
+// without touching the global jest config.
+jest.mock('../../../common/helpers', () => ({
+  isUserDisabled: () => false,
+}));
+
 import { Test, TestingModule } from '@nestjs/testing';
+import { JwtModule } from '@nestjs/jwt';
+import * as jwt from 'jsonwebtoken';
 import { TokenService } from './token.service';
+import { EnvironmentService } from '../../../integrations/environment/environment.service';
+import { createMockUser } from '../../../test-utils/test-helpers';
 
 describe('TokenService', () => {
   let service: TokenService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [TokenService],
+      imports: [
+        // Mirror production: a module-level expiresIn default exists, intended
+        // for short-lived access tokens. generateApiToken must NOT inherit it.
+        JwtModule.register({
+          secret: 'test-secret',
+          signOptions: { expiresIn: '90d', issuer: 'Docmost' },
+        }),
+      ],
+      providers: [
+        TokenService,
+        {
+          provide: EnvironmentService,
+          useValue: { getAppSecret: () => 'test-secret' },
+        },
+      ],
     }).compile();
 
     service = module.get<TokenService>(TokenService);
@@ -14,5 +40,62 @@ describe('TokenService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('generateApiToken', () => {
+    const user = createMockUser();
+
+    it('uses a long-lived exp (~100y) when no expiresIn is supplied, instead of inheriting the 90d module default', async () => {
+      const before = Math.floor(Date.now() / 1000);
+
+      const token = await service.generateApiToken({
+        apiKeyId: 'key-id-1',
+        user,
+        workspaceId: user.workspaceId,
+      });
+
+      const decoded = jwt.decode(token) as {
+        exp?: number;
+        iat?: number;
+        type?: string;
+        apiKeyId?: string;
+        sub?: string;
+        workspaceId?: string;
+      } | null;
+      expect(decoded).not.toBeNull();
+      expect(decoded!.type).toBe('api_key');
+      expect(decoded!.apiKeyId).toBe('key-id-1');
+      expect(decoded!.sub).toBe(user.id);
+      expect(decoded!.workspaceId).toBe(user.workspaceId);
+
+      // Must NOT be the leaky 90d module default (the bug). Anything past one
+      // year out is fine; we use 100y in production.
+      const ninetyDaysSeconds = 90 * 24 * 60 * 60;
+      const oneYearSeconds = 365 * 24 * 60 * 60;
+      expect(decoded!.iat).toBeDefined();
+      expect(decoded!.exp).toBeDefined();
+      expect(decoded!.iat!).toBeGreaterThanOrEqual(before);
+      const ttl = decoded!.exp! - decoded!.iat!;
+      expect(ttl).toBeGreaterThan(oneYearSeconds);
+      expect(ttl).not.toBe(ninetyDaysSeconds);
+    });
+
+    it('respects an explicit numeric expiresIn (seconds) when supplied', async () => {
+      const before = Math.floor(Date.now() / 1000);
+
+      const token = await service.generateApiToken({
+        apiKeyId: 'key-id-2',
+        user,
+        workspaceId: user.workspaceId,
+        expiresIn: 3600,
+      });
+
+      const decoded = jwt.decode(token) as { exp?: number; iat?: number } | null;
+      expect(decoded).not.toBeNull();
+      expect(decoded!.exp).toBeDefined();
+      expect(decoded!.iat).toBeDefined();
+      expect(decoded!.exp! - decoded!.iat!).toBe(3600);
+      expect(decoded!.iat!).toBeGreaterThanOrEqual(before);
+    });
   });
 });

--- a/apps/server/src/core/auth/services/token.service.spec.ts
+++ b/apps/server/src/core/auth/services/token.service.spec.ts
@@ -1,7 +1,3 @@
-// `common/helpers` transitively imports `nanoid` (ESM-only), which the repo's
-// current jest config does not transform. We don't exercise any of those
-// helpers in this spec, so stub the barrel out to keep this file runnable
-// without touching the global jest config.
 jest.mock('../../../common/helpers', () => ({
   isUserDisabled: () => false,
 }));

--- a/apps/server/src/core/auth/services/token.service.ts
+++ b/apps/server/src/core/auth/services/token.service.ts
@@ -112,7 +112,15 @@ export class TokenService {
       type: JwtType.API_KEY,
     };
 
-    return this.jwtService.sign(payload, expiresIn ? { expiresIn } : {});
+    // Always pass an explicit expiresIn so we override the module-level
+    // signOptions.expiresIn default (currently '90d', intended for short-lived
+    // access tokens). When the API key was created with "no expiration", fall
+    // back to a 100-year window — practically equivalent to never expiring,
+    // and required because jsonwebtoken's option validator rejects an
+    // `expiresIn: undefined` override. The DB's apiKey.expiresAt column
+    // remains the authoritative source of truth for API key expiry, enforced
+    // by ApiKeyService.validateApiKey.
+    return this.jwtService.sign(payload, { expiresIn: expiresIn ?? '100y' });
   }
 
   async verifyJwt(token: string, tokenType: string) {

--- a/apps/server/src/core/auth/services/token.service.ts
+++ b/apps/server/src/core/auth/services/token.service.ts
@@ -112,14 +112,8 @@ export class TokenService {
       type: JwtType.API_KEY,
     };
 
-    // Always pass an explicit expiresIn so we override the module-level
-    // signOptions.expiresIn default (currently '90d', intended for short-lived
-    // access tokens). When the API key was created with "no expiration", fall
-    // back to a 100-year window — practically equivalent to never expiring,
-    // and required because jsonwebtoken's option validator rejects an
-    // `expiresIn: undefined` override. The DB's apiKey.expiresAt column
-    // remains the authoritative source of truth for API key expiry, enforced
-    // by ApiKeyService.validateApiKey.
+    // due to the default value of 90 days, if no expiry is provided
+    // 100y are set as a maximum length
     return this.jwtService.sign(payload, { expiresIn: expiresIn ?? '100y' });
   }
 


### PR DESCRIPTION
hey @Vito0912, I came across this one when testing out the MCP PR. In case you want to merge this one.

I did not want to touch too many codeparts to fix this one properly. I believe a scoped token system would be better so we could have native no expiration tokens without the security risk.

API keys created via Settings → API management with the "no expiration" option were silently issued JWTs that carried a 90-day exp claim. The DB column correctly stored expires_at = NULL and ApiKeyService.validateApiKey honored that, but the JWT verify layer (passport-jwt in JwtStrategy and jwtService.verifyAsync in McpAuthGuard) enforces the standard exp claim first. After 90 days the token starts failing every request even though the DB still considers the key valid forever — and there is no refresh endpoint, so users have to revoke + recreate.

Root cause: TokenService.generateApiToken was calling
  jwtService.sign(payload, expiresIn ? { expiresIn } : {})
When expiresIn is undefined, the empty options object inherits the module-level signOptions.expiresIn default ('90d', set in TokenModule for short-lived access tokens). passing { expiresIn: undefined } would also fail because jsonwebtoken@9 validates options strictly and rejects undefined.
